### PR TITLE
add image->pixels function

### DIFF
--- a/src/blurhash/core.clj
+++ b/src/blurhash/core.clj
@@ -5,9 +5,8 @@
            (java.awt Color)
            (javax.imageio ImageIO)))
 
-(defn file->pixels [path]
-  (let [image (-> path io/file ImageIO/read)
-        width (.getWidth image)]
+(defn image->pixels [^BufferedImage image]
+  (let [width (.getWidth image)]
     (map vec
          (partition width
                     (for [row-index (range (.getHeight image))
@@ -17,6 +16,9 @@
                       (vector (.getRed rgb-object)
                               (.getGreen rgb-object)
                               (.getBlue rgb-object)))))))
+
+(defn file->pixels [path]
+  (-> path io/file ImageIO/read image->pixels))
 
 (defn pixels->file [pixels ^String filename]
   (let [height (count pixels)

--- a/test/clj/blurhash/core_test.clj
+++ b/test/clj/blurhash/core_test.clj
@@ -1,7 +1,8 @@
 (ns blurhash.core-test
-  (:require [blurhash.core :refer [file->pixels pixels->file]]
+  (:require [blurhash.core :refer [file->pixels image->pixels pixels->file]]
             [clojure.java.io :as io]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all])
+  (:import (javax.imageio ImageIO)))
 
 (def test-file-name
   "./resources/example.jpg")
@@ -19,6 +20,13 @@
       (io/delete-file temp-file))))
 
 (use-fixtures :once with-temp-file-cleaned)
+
+(deftest image->pixels-test
+  (let [blurred-image  (-> blurred-test-file-name io/file ImageIO/read)
+        blurred-matrix (image->pixels blurred-image)]
+    (testing "Dimensions match"
+      (is (= 236 (count blurred-matrix)))
+      (is (= 300 (count (first blurred-matrix)))))))
 
 (deftest file->pixels-test
   (let [blurred-matrix (file->pixels blurred-test-file-name)]


### PR DESCRIPTION
Today the function `file->pixel` gets the path of the image in order to build its pixels matrix.

The problem:
When I am using this function I have to download the file locally, deliver it's path, and delete it when im done.
Since I am working with file of type `InputStream`, I don't really need to download (and later delete) it.

Im suggesting this fix in order to avoid the redundant save/delete operations on my side, by allowing pass the BufferedImage instead of the path of the image.
